### PR TITLE
Remove manual DEBUG logging for aioaquarea

### DIFF
--- a/custom_components/aquarea/__init__.py
+++ b/custom_components/aquarea/__init__.py
@@ -17,7 +17,6 @@ from .const import ATTRIBUTION, CLIENT, DEVICES, DOMAIN
 from .coordinator import AquareaDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-logging.getLogger("custom_components.aquarea.aioaquarea").setLevel(logging.DEBUG) # Set aioaquarea logging to DEBUG
 
 PLATFORMS: list[Platform] = [
     Platform.CLIMATE,


### PR DESCRIPTION
I propose this change so that DEBUG logs only appear when explicitly enabled, 
preventing them from cluttering the log. They can still be turned on manually in Home Assistant whenever needed.